### PR TITLE
Change int type for SCNotification Scintilla

### DIFF
--- a/3PA/NppCore/DocumentLines.cs
+++ b/3PA/NppCore/DocumentLines.cs
@@ -107,11 +107,11 @@ namespace _3PA.NppCore {
         public void Reset() {
             Init();
             var scn = new SCNotification {
-                linesAdded = SciGetLineCount() - 1,
-                position = 0,
-                length = SciGetLength()
+                linesAdded = new IntPtr(SciGetLineCount() - 1),
+                position = IntPtr.Zero,
+                length = new IntPtr(SciGetLength())
             };
-            scn.text = Api.Send(SciMsg.SCI_GETRANGEPOINTER, new IntPtr(scn.position), new IntPtr(scn.length));
+            scn.text = Api.Send(SciMsg.SCI_GETRANGEPOINTER, scn.position, scn.length);
             OnScnModified(scn, true, Sci.Encoding);
         }
 
@@ -153,16 +153,16 @@ namespace _3PA.NppCore {
         /// </summary>
         /// <param name="scn"></param>
         private void OnDeletedText(SCNotification scn) {
-            var startLine = SciLineFromPosition(scn.position);
-            if (scn.linesAdded == 0) {
-                var delCharLenght = GetCharCount(scn.text, scn.length);
+            var startLine = SciLineFromPosition(scn.position.ToInt32());
+            if (scn.linesAdded == IntPtr.Zero) {
+                var delCharLenght = GetCharCount(scn.text, scn.length.ToInt32());
                 SetHoleInLine(startLine, -delCharLenght);
             } else {
                 var lineByteStart = SciPositionFromLine(startLine);
                 var lineByteLength = SciLineLength(startLine);
                 var delCharLenght = -(GetCharCount(lineByteStart, lineByteLength) - LineCharLength(startLine));
                 FillTheHole();
-                for (int i = 0; i < -scn.linesAdded; i++) {
+                for (int i = 0; i < -scn.linesAdded.ToInt32(); i++) {
                     delCharLenght += LineCharLength(startLine + 1);
                     _linesList.RemoveAt(startLine + 1);
                 }
@@ -176,9 +176,9 @@ namespace _3PA.NppCore {
         /// </summary>
         /// <param name="scn"></param>
         private void OnInsertedText(SCNotification scn) {
-            var startLine = SciLineFromPosition(scn.position);
-            if (scn.linesAdded == 0) {
-                var insCharLenght = GetCharCount(scn.text, scn.length);
+            var startLine = SciLineFromPosition(scn.position.ToInt32());
+            if (scn.linesAdded == IntPtr.Zero) {
+                var insCharLenght = GetCharCount(scn.text, scn.length.ToInt32());
                 SetHoleInLine(startLine, insCharLenght);
             } else {
                 var startCharPos = CharPositionFromLine(startLine);
@@ -187,7 +187,7 @@ namespace _3PA.NppCore {
                 var lineCharLenght = GetCharCount(lineByteStart, lineByteLength);
                 var insCharLenght = lineCharLenght - LineCharLength(startLine);
                 FillTheHole();
-                for (int i = 0; i < scn.linesAdded; i++) {
+                for (int i = 0; i < scn.linesAdded.ToInt32(); i++) {
                     startCharPos += lineCharLenght;
                     var line = startLine + i + 1;
                     lineByteStart += lineByteLength;
@@ -196,7 +196,7 @@ namespace _3PA.NppCore {
                     insCharLenght += lineCharLenght;
                     _linesList.Insert(line, startCharPos);
                 }
-                SetHoleInLine(startLine + scn.linesAdded, insCharLenght);
+                SetHoleInLine(startLine + scn.linesAdded.ToInt32(), insCharLenght);
                 FillTheHole();
 
                 // We should not have a null length, but we actually can :
@@ -205,7 +205,7 @@ namespace _3PA.NppCore {
                 // so in that case, we need to refresh the info when the text is actually inserted, that is after updateui
                 // Clarification : the notification sent is correct (nb lines > 0, length, text are ok), but calling SciLineLength
                 // will always return 0 at this moment!
-                if (scn.length > 0 && TextLength == 0)
+                if (scn.length.ToInt32() > 0 && TextLength == 0)
                     NotificationsPublisher.ActionsAfterUpdateUi.Enqueue(Reset);
             }
         }

--- a/3PA/NppCore/NotificationsPublisher.cs
+++ b/3PA/NppCore/NotificationsPublisher.cs
@@ -150,21 +150,21 @@ namespace _3PA.NppCore {
                                             }
 
                                             // only 1 char appears to be modified
-                                            if (nc.length <= 2) {
+                                            if (nc.length.ToInt32() <= 2) {
                                                 // get the char
                                                 var bytes = (byte*) nc.text;
-                                                var arrbyte = new byte[nc.length];
+                                                var arrbyte = new byte[nc.length.ToInt32()];
                                                 int index;
-                                                for (index = 0; index < nc.length; index++)
+                                                for (index = 0; index < nc.length.ToInt32(); index++)
                                                     arrbyte[index] = bytes[index];
                                                 var c = encoding.GetChars(arrbyte);
                                                 var cLength = c.Length;
                                                 // do we really have a 1 char input?
                                                 if (cLength == 1 || (cLength == 2 && c[0] == '\r')) {
                                                     if (insertedText) {
-                                                        ActionsAfterUpdateUi.Enqueue(() => Plug.OnCharAdded(c[0], nc.position));
+                                                        ActionsAfterUpdateUi.Enqueue(() => Plug.OnCharAdded(c[0], nc.position.ToInt32()));
                                                     } else {
-                                                        ActionsAfterUpdateUi.Enqueue(() => Plug.OnCharDeleted(c[0], nc.position));
+                                                        ActionsAfterUpdateUi.Enqueue(() => Plug.OnCharDeleted(c[0], nc.position.ToInt32()));
                                                     }
                                                     singleCharModification = true;
                                                 }
@@ -178,7 +178,7 @@ namespace _3PA.NppCore {
 
                             case (uint) SciNotif.SCN_STYLENEEDED:
                                 // if we use the contained lexer, we will receive this notification and we will have to style the text
-                                Plug.OnStyleNeeded(Sci.GetEndStyled(), nc.position);
+                                Plug.OnStyleNeeded(Sci.GetEndStyled(), nc.position.ToInt32());
                                 return;
 
                             case (uint) SciNotif.SCN_MARGINCLICK:

--- a/3PA/NppCore/SciHeader.cs
+++ b/3PA/NppCore/SciHeader.cs
@@ -37,17 +37,17 @@ namespace _3PA.NppCore {
     [StructLayout(LayoutKind.Sequential)]
     public struct SCNotification {
         public Sci_NotifyHeader nmhdr;
-        public int position; /* SCN_STYLENEEDED, SCN_MODIFIED, SCN_DWELLSTART, SCN_DWELLEND */
+        public IntPtr position; /* SCN_STYLENEEDED, SCN_MODIFIED, SCN_DWELLSTART, SCN_DWELLEND */
         public int ch; /* SCN_CHARADDED, SCN_KEY */
         public int modifiers; /* SCN_KEY */
         public int modificationType; /* SCN_MODIFIED */
         public IntPtr text; /* SCN_MODIFIED, SCN_USERLISTSELECTION, SCN_AUTOCSELECTION */
-        public int length; /* SCN_MODIFIED */
-        public int linesAdded; /* SCN_MODIFIED */
+        public IntPtr length; /* SCN_MODIFIED */
+        public IntPtr linesAdded; /* SCN_MODIFIED */
         public int message; /* SCN_MACRORECORD */
         public IntPtr wParam; /* SCN_MACRORECORD */
         public IntPtr lParam; /* SCN_MACRORECORD */
-        public int line; /* SCN_MODIFIED */
+        public IntPtr line; /* SCN_MODIFIED */
         public int foldLevelNow; /* SCN_MODIFIED */
         public int foldLevelPrev; /* SCN_MODIFIED */
         public int margin; /* SCN_MARGINCLICK */
@@ -55,7 +55,7 @@ namespace _3PA.NppCore {
         public int x; /* SCN_DWELLSTART, SCN_DWELLEND */
         public int y; /* SCN_DWELLSTART, SCN_DWELLEND */
         public int token; /* SCN_MODIFIED with SC_MOD_CONTAINER */
-        public int annotationLinesAdded; /* SC_MOD_CHANGEANNOTATION */
+        public IntPtr annotationLinesAdded; /* SC_MOD_CHANGEANNOTATION */
         public int updated; /* SCN_UPDATEUI */
         public int listCompletionMethod; /* SCN_AUTOCSELECTION, SCN_AUTOCCOMPLETED, SCN_USERLISTSELECTION */
 

--- a/3PA/Plug.cs
+++ b/3PA/Plug.cs
@@ -691,9 +691,9 @@ namespace _3PA {
             // click on the error margin
             if (nc.margin == OpenedFilesInfo.ErrorMarginNumber) {
                 // if it's an error symbol that has been clicked, the error on the line will be cleared
-                if (!OpenedFilesInfo.ClearLineErrors(Sci.LineFromPosition(nc.position))) {
+                if (!OpenedFilesInfo.ClearLineErrors(Sci.LineFromPosition(nc.position.ToInt32()))) {
                     // if nothing has been cleared, we go to the next error position
-                    OpenedFilesInfo.GoToNextError(Sci.LineFromPosition(nc.position));
+                    OpenedFilesInfo.GoToNextError(Sci.LineFromPosition(nc.position.ToInt32()));
                 }
             }
         }


### PR DESCRIPTION
According to https://github.com/jacobslusser/ScintillaNET/pull/447, a change in several integer variables causes nc.modificationType equals to 0 (due to Scintilla updates). This result causes a behavior problem in the NotificationPublisher.cs (case SCN_MODIFIED).
This problem appears only in 64-bits Notepad++ 7.7 and above and related to #263 .