### PR TITLE
Add support for reading autocompletion files when language definition is in userDefineLangs directory

### DIFF
--- a/3PA/NppCore/NppConf.cs
+++ b/3PA/NppCore/NppConf.cs
@@ -100,6 +100,10 @@ namespace _3PA.NppCore {
             /// </summary>
             public bool MultiSelectionEnabled { get; private set; }
 
+            public string DirectoryNppUserDefineLangs {
+                get { return Path.Combine(FolderBaseConf, @"userDefineLangs"); }
+            }
+
             public string FileNppUserDefinedLang {
                 get { return Path.Combine(FolderBaseConf, @"userDefineLang.xml"); }
             }

--- a/3PA/NppCore/NppLang.cs
+++ b/3PA/NppCore/NppLang.cs
@@ -101,6 +101,17 @@ namespace _3PA.NppCore {
             } catch (Exception e) {
                 ErrorHandler.LogError(e, "Error parsing " + Npp.ConfXml.FileNppStylersXml);
             }
+
+            // from directory userDefineLangs/
+            try {
+                var filenames = Directory.GetFiles(Npp.ConfXml.DirectoryNppUserDefineLangs, "*.xml");
+                var nodes = filenames.Select(filename => new NanoXmlDocument(Utils.ReadAllText(filename)).RootNode["UserLang"]);
+                FillDictionaries(nodes.ToList());
+            }
+            catch (Exception e) {
+                ErrorHandler.LogError(e, "Error parsing " + Npp.ConfXml.FileNppLangsXml);
+            }
+
         }
 
         /// <summary>


### PR DESCRIPTION
# Description of the pull request
3P would not autocomplete or show API tips for a custom user defined language, when the autocompletion file was placed in Notepad++'s userDefineLangs directory.

This PR implements support for these autocompletion files.

### Check List
- [x] I tested this very carefully
- [No framework for testing autocompletion] I added an automated test
- [x] I tried to blend into the current coding style
