### PR TITLE
Support linefeed in function descriptions

### DIFF
--- a/3PA/MainFeatures/AutoCompletionFeature/CompletionItem.cs
+++ b/3PA/MainFeatures/AutoCompletionFeature/CompletionItem.cs
@@ -900,7 +900,7 @@ namespace _3PA.MainFeatures.AutoCompletionFeature {
             if (NppKeyword.Overloads != null) {
                 toDisplay.Append(HtmlHelper.FormatSubtitle("OVERLOADS"));
                 foreach (var overload in NppKeyword.Overloads) {
-                    toDisplay.Append("<div>" + overload.Description + "</div>");
+                    toDisplay.Append("<div>" + overload.Description.RegexReplace("&#x(0+)a;", "<br/>") + "</div>");
                     toDisplay.Append(@"<div class='ToolTipcodeSnippet'>");
                     toDisplay.Append("<b>" + DisplayText + "</b> (");
                     toDisplay.Append(string.Join(", ", overload.Params));


### PR DESCRIPTION
### Description of the pull request
Notepad++ supports &#x0a; as a linebreak in function descriptions - this is a documented feature in the autocomplete functionality (https://npp-user-manual.org/docs/auto-completion/#auto-completion-file-format)

This PR extends the linefeed functionality to the 3P plugin.

### Check List
- [x] I tested this very carefully
- [No framework in place for testing this] I added an automated test
- [x] I tried to blend into the current coding style
